### PR TITLE
Added mention of Linux savedata path for src/lib/WelcomeMessage.svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The default Steam save file location for Windows is:
 ```
 %userprofile%\AppData\LocalLow\RedCandleGames\NineSols
 ```
+For Linux:
+```
+/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols/
+```
 
 ## Technical info⚙️
 

--- a/src/lib/WelcomeMessage.svelte
+++ b/src/lib/WelcomeMessage.svelte
@@ -24,24 +24,24 @@
     <div class="pt-1 pb-4">
 
       <!-- Title -->
-      <div class="text-4xl text-bold text-secondary"> Attention! </div>
+      <div class="text-4xl text-bold text-secondary text-center"> Attention! </div>
     
       <!-- Save file location -->
-      <div class="py-2">
+      <div class="py-2 text-center">
         <div> On Windows, Save files are located at: </div>
           <div class="relative h-[1.2em]"> 
-          <div class="absolute text-info hover:underline select-all text-nowrap">%userprofile%\AppData\LocalLow\RedCandleGames\NineSols</div>
+            <div class="text-info hover:underline select-all break-all">%userprofile%\AppData\LocalLow\RedCandleGames\NineSols</div>
         </div>
-		<div> On Linux(Proton Prefix): </div>
+      <div class="mt-2">On Linux (Proton Prefix):</div>
           <div class="relative h-[1.2em]"> 
-          <div class="absolute text-info hover:underline select-all text-nowrap">/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols/saveslot0/</div>
+            <div class="text-info hover:underline select-all break-all">/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols</div>
         </div>
       </div>
 
       <!-- Instructions -->
-      <div class="flex flex-col max-w-95 w-max">
+      <div class="flex flex-col max-w-[40rem] w-full mx-auto">
         <!-- Quick guide -->
-        {@render horizontalLine('Quick guide', 'mt-4')}
+        {@render horizontalLine('Quick Guide', 'mt-4')}
         <li> Please, <span class="font-bold">make a backup</span> of your original save file </li>
         <li> Select or drag'n'drop the save file you want to modify </li>
         <li> Wait patiently for the file to open, it usually takes a few seconds </li>

--- a/src/lib/WelcomeMessage.svelte
+++ b/src/lib/WelcomeMessage.svelte
@@ -36,10 +36,6 @@
           <div class="relative h-[1.2em]"> 
             <div class="text-info hover:underline select-all break-all">/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols</div>
         </div>
-      <div class="mt-2">On macOS:</div>
-          <div class="relative h-[1.2em]">
-            <div class="text-info hover:underline select-all break-all">$HOME/Library/Application Support/com.RedCandleGames.NineSols</div>
-        </div>
       </div>
 
       <!-- Instructions -->

--- a/src/lib/WelcomeMessage.svelte
+++ b/src/lib/WelcomeMessage.svelte
@@ -29,11 +29,11 @@
       <!-- Save file location -->
       <div class="py-2">
         <div> On Windows, Save files are located at: </div>
-        <div class="relative h-[1.2em]"> 
+          <div class="relative h-[1.2em]"> 
           <div class="absolute text-info hover:underline select-all text-nowrap">%userprofile%\AppData\LocalLow\RedCandleGames\NineSols</div>
         </div>
-				<div> On Linux(Proton Prefix): </div>
-        <div class="relative h-[1.2em]"> 
+		<div> On Linux(Proton Prefix): </div>
+          <div class="relative h-[1.2em]"> 
           <div class="absolute text-info hover:underline select-all text-nowrap">/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols/saveslot0/</div>
         </div>
       </div>

--- a/src/lib/WelcomeMessage.svelte
+++ b/src/lib/WelcomeMessage.svelte
@@ -28,9 +28,13 @@
     
       <!-- Save file location -->
       <div class="py-2">
-        <div> Save files are located at: </div>
+        <div> On Windows, Save files are located at: </div>
         <div class="relative h-[1.2em]"> 
           <div class="absolute text-info hover:underline select-all text-nowrap">%userprofile%\AppData\LocalLow\RedCandleGames\NineSols</div>
+        </div>
+				<div> On Linux(Proton Prefix): </div>
+        <div class="relative h-[1.2em]"> 
+          <div class="absolute text-info hover:underline select-all text-nowrap">/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols/saveslot0/</div>
         </div>
       </div>
 

--- a/src/lib/WelcomeMessage.svelte
+++ b/src/lib/WelcomeMessage.svelte
@@ -36,6 +36,10 @@
           <div class="relative h-[1.2em]"> 
             <div class="text-info hover:underline select-all break-all">/home/(username)/.steam/steam/steamapps/compatdata/1809540/pfx/drive_c/users/steamuser/AppData/LocalLow/RedCandleGames/NineSols</div>
         </div>
+      <div class="mt-2">On macOS:</div>
+          <div class="relative h-[1.2em]">
+            <div class="text-info hover:underline select-all break-all">$HOME/Library/Application Support/com.RedCandleGames.NineSols</div>
+        </div>
       </div>
 
       <!-- Instructions -->


### PR DESCRIPTION
Nice to meet you. I saw your work on Nine Sols Discord, and realized a lack of mention where the save file is saved for Linux (Proton) players, thus I decided to mention on that part. (as well as for README)

This is my first ever crack at Svelte, so my edit of the code might made code messy, if that's the case, sorry.